### PR TITLE
Use strong tags for Phase 1 financing highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                             <ul class="list-disc list-inside mt-2 text-sm text-gray-600">
                                 <li>Secure the land with a Purchase and Sale Agreement.</li>
                                 <li>Engage project team (Architect, Engineer, General Contractor, Environmental Consultant).</li>
-                                <li>Initiate talks with lenders to lock in <strong>6% fixed-rate financing</strong> at a <strong>70% loan-to-cost</strong>.</li>
+                                <li>Initiate talks with lenders to lock in <strong>6% fixed-rate financing at a 70% loan-to-cost</strong>.</li>
                             </ul>
                         </div>
                         <div class="timeline-item mt-8">

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                             <ul class="list-disc list-inside mt-2 text-sm text-gray-600">
                                 <li>Secure the land with a Purchase and Sale Agreement.</li>
                                 <li>Engage project team (Architect, Engineer, General Contractor, Environmental Consultant).</li>
-                                <li>Initiate talks with lenders to lock in **6% fixed-rate financing** at a **70% loan-to-cost**.</li>
+                                <li>Initiate talks with lenders to lock in <strong>6% fixed-rate financing</strong> at a <strong>70% loan-to-cost</strong>.</li>
                             </ul>
                         </div>
                         <div class="timeline-item mt-8">


### PR DESCRIPTION
## Summary
- replace Markdown-style bold with HTML strong tags in the Phase 1 financing bullet so the emphasis renders correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e3215798c832f95437ba25918de6f)